### PR TITLE
Remove static methods: Size

### DIFF
--- a/src/Neo.Cryptography.BLS12_381/Fp.cs
+++ b/src/Neo.Cryptography.BLS12_381/Fp.cs
@@ -9,15 +9,15 @@ using static Neo.Cryptography.BLS12_381.MathUtility;
 
 namespace Neo.Cryptography.BLS12_381;
 
-[StructLayout(LayoutKind.Explicit, Size = Size)]
+[StructLayout(LayoutKind.Explicit, Size = SIZE)]
 public readonly struct Fp : IEquatable<Fp>, INumber<Fp>
 {
-    public const int Size = 48;
-    public const int SizeL = Size / sizeof(ulong);
+    public const int SIZE = 48;
+    public const int LSIZE = SIZE / sizeof(ulong);
 
     private static readonly Fp _zero = new();
 
-    static int INumber<Fp>.Size => Size;
+    public int Size => SIZE;
     public static ref readonly Fp Zero => ref _zero;
     public static ref readonly Fp One => ref R;
 
@@ -25,10 +25,10 @@ public readonly struct Fp : IEquatable<Fp>, INumber<Fp>
 
     public static Fp FromBytes(ReadOnlySpan<byte> data)
     {
-        if (data.Length != Size)
-            throw new FormatException($"The argument `{nameof(data)}` should contain {Size} bytes.");
+        if (data.Length != SIZE)
+            throw new FormatException($"The argument `{nameof(data)}` should contain {SIZE} bytes.");
 
-        Span<ulong> tmp = stackalloc ulong[SizeL];
+        Span<ulong> tmp = stackalloc ulong[LSIZE];
         BinaryPrimitives.TryReadUInt64BigEndian(data[0..8], out tmp[5]);
         BinaryPrimitives.TryReadUInt64BigEndian(data[8..16], out tmp[4]);
         BinaryPrimitives.TryReadUInt64BigEndian(data[16..24], out tmp[3]);
@@ -68,7 +68,7 @@ public readonly struct Fp : IEquatable<Fp>, INumber<Fp>
 
     public static Fp Random(RandomNumberGenerator rng)
     {
-        Span<byte> buffer = stackalloc byte[Size * 2];
+        Span<byte> buffer = stackalloc byte[SIZE * 2];
         rng.GetBytes(buffer);
         Span<Fp> d = MemoryMarshal.Cast<byte, Fp>(buffer);
         return d[0] * R2 + d[1] * R3;
@@ -277,12 +277,12 @@ public readonly struct Fp : IEquatable<Fp>, INumber<Fp>
             var (t0, t1, t2, t3, t4, t5, t6) = (u[0], u[1], u[2], u[3], u[4], u[5], 0ul);
             for (int i = 0; i < length; i++)
             {
-                (t0, carry) = Mac(t0, au[i * SizeL + j], bu[i * SizeL + 0], 0);
-                (t1, carry) = Mac(t1, au[i * SizeL + j], bu[i * SizeL + 1], carry);
-                (t2, carry) = Mac(t2, au[i * SizeL + j], bu[i * SizeL + 2], carry);
-                (t3, carry) = Mac(t3, au[i * SizeL + j], bu[i * SizeL + 3], carry);
-                (t4, carry) = Mac(t4, au[i * SizeL + j], bu[i * SizeL + 4], carry);
-                (t5, carry) = Mac(t5, au[i * SizeL + j], bu[i * SizeL + 5], carry);
+                (t0, carry) = Mac(t0, au[i * LSIZE + j], bu[i * LSIZE + 0], 0);
+                (t1, carry) = Mac(t1, au[i * LSIZE + j], bu[i * LSIZE + 1], carry);
+                (t2, carry) = Mac(t2, au[i * LSIZE + j], bu[i * LSIZE + 2], carry);
+                (t3, carry) = Mac(t3, au[i * LSIZE + j], bu[i * LSIZE + 3], carry);
+                (t4, carry) = Mac(t4, au[i * LSIZE + j], bu[i * LSIZE + 4], carry);
+                (t5, carry) = Mac(t5, au[i * LSIZE + j], bu[i * LSIZE + 5], carry);
                 (t6, _) = Adc(t6, 0, carry);
             }
 
@@ -364,7 +364,7 @@ public readonly struct Fp : IEquatable<Fp>, INumber<Fp>
     public static Fp operator *(in Fp a, in Fp b)
     {
         ReadOnlySpan<ulong> s = a.GetSpanU64(), r = b.GetSpanU64();
-        Span<ulong> t = stackalloc ulong[SizeL * 2];
+        Span<ulong> t = stackalloc ulong[LSIZE * 2];
         ulong carry;
 
         (t[0], carry) = Mac(0, s[0], r[0], 0);

--- a/src/Neo.Cryptography.BLS12_381/Fp.cs
+++ b/src/Neo.Cryptography.BLS12_381/Fp.cs
@@ -9,14 +9,15 @@ using static Neo.Cryptography.BLS12_381.MathUtility;
 
 namespace Neo.Cryptography.BLS12_381;
 
-[StructLayout(LayoutKind.Explicit, Size = Size)]
+[StructLayout(LayoutKind.Explicit, Size = SIZE)]
 public readonly struct Fp : IEquatable<Fp>, INumber<Fp>
 {
-    public const int Size = 48;
-    public const int SizeL = Size / sizeof(ulong);
+    public const int SIZE = 48;
+    public const int LSIZE = SIZE / sizeof(ulong);
 
     private static readonly Fp _zero = new();
 
+    public int Size => SIZE;
     public static ref readonly Fp Zero => ref _zero;
     public static ref readonly Fp One => ref R;
 
@@ -24,10 +25,10 @@ public readonly struct Fp : IEquatable<Fp>, INumber<Fp>
 
     public static Fp FromBytes(ReadOnlySpan<byte> data)
     {
-        if (data.Length != Size)
-            throw new FormatException($"The argument `{nameof(data)}` should contain {Size} bytes.");
+        if (data.Length != SIZE)
+            throw new FormatException($"The argument `{nameof(data)}` should contain {SIZE} bytes.");
 
-        Span<ulong> tmp = stackalloc ulong[SizeL];
+        Span<ulong> tmp = stackalloc ulong[LSIZE];
         BinaryPrimitives.TryReadUInt64BigEndian(data[0..8], out tmp[5]);
         BinaryPrimitives.TryReadUInt64BigEndian(data[8..16], out tmp[4]);
         BinaryPrimitives.TryReadUInt64BigEndian(data[16..24], out tmp[3]);
@@ -67,7 +68,7 @@ public readonly struct Fp : IEquatable<Fp>, INumber<Fp>
 
     public static Fp Random(RandomNumberGenerator rng)
     {
-        Span<byte> buffer = stackalloc byte[Size * 2];
+        Span<byte> buffer = stackalloc byte[SIZE * 2];
         rng.GetBytes(buffer);
         Span<Fp> d = MemoryMarshal.Cast<byte, Fp>(buffer);
         return d[0] * R2 + d[1] * R3;
@@ -276,12 +277,12 @@ public readonly struct Fp : IEquatable<Fp>, INumber<Fp>
             var (t0, t1, t2, t3, t4, t5, t6) = (u[0], u[1], u[2], u[3], u[4], u[5], 0ul);
             for (int i = 0; i < length; i++)
             {
-                (t0, carry) = Mac(t0, au[i * SizeL + j], bu[i * SizeL + 0], 0);
-                (t1, carry) = Mac(t1, au[i * SizeL + j], bu[i * SizeL + 1], carry);
-                (t2, carry) = Mac(t2, au[i * SizeL + j], bu[i * SizeL + 2], carry);
-                (t3, carry) = Mac(t3, au[i * SizeL + j], bu[i * SizeL + 3], carry);
-                (t4, carry) = Mac(t4, au[i * SizeL + j], bu[i * SizeL + 4], carry);
-                (t5, carry) = Mac(t5, au[i * SizeL + j], bu[i * SizeL + 5], carry);
+                (t0, carry) = Mac(t0, au[i * LSIZE + j], bu[i * LSIZE + 0], 0);
+                (t1, carry) = Mac(t1, au[i * LSIZE + j], bu[i * LSIZE + 1], carry);
+                (t2, carry) = Mac(t2, au[i * LSIZE + j], bu[i * LSIZE + 2], carry);
+                (t3, carry) = Mac(t3, au[i * LSIZE + j], bu[i * LSIZE + 3], carry);
+                (t4, carry) = Mac(t4, au[i * LSIZE + j], bu[i * LSIZE + 4], carry);
+                (t5, carry) = Mac(t5, au[i * LSIZE + j], bu[i * LSIZE + 5], carry);
                 (t6, _) = Adc(t6, 0, carry);
             }
 
@@ -363,7 +364,7 @@ public readonly struct Fp : IEquatable<Fp>, INumber<Fp>
     public static Fp operator *(in Fp a, in Fp b)
     {
         ReadOnlySpan<ulong> s = a.GetSpanU64(), r = b.GetSpanU64();
-        Span<ulong> t = stackalloc ulong[SizeL * 2];
+        Span<ulong> t = stackalloc ulong[LSIZE * 2];
         ulong carry;
 
         (t[0], carry) = Mac(0, s[0], r[0], 0);

--- a/src/Neo.Cryptography.BLS12_381/Fp.cs
+++ b/src/Neo.Cryptography.BLS12_381/Fp.cs
@@ -9,15 +9,14 @@ using static Neo.Cryptography.BLS12_381.MathUtility;
 
 namespace Neo.Cryptography.BLS12_381;
 
-[StructLayout(LayoutKind.Explicit, Size = SIZE)]
+[StructLayout(LayoutKind.Explicit, Size = Size)]
 public readonly struct Fp : IEquatable<Fp>, INumber<Fp>
 {
-    public const int SIZE = 48;
-    public const int LSIZE = SIZE / sizeof(ulong);
+    public const int Size = 48;
+    public const int SizeL = Size / sizeof(ulong);
 
     private static readonly Fp _zero = new();
 
-    public int Size => SIZE;
     public static ref readonly Fp Zero => ref _zero;
     public static ref readonly Fp One => ref R;
 
@@ -25,10 +24,10 @@ public readonly struct Fp : IEquatable<Fp>, INumber<Fp>
 
     public static Fp FromBytes(ReadOnlySpan<byte> data)
     {
-        if (data.Length != SIZE)
-            throw new FormatException($"The argument `{nameof(data)}` should contain {SIZE} bytes.");
+        if (data.Length != Size)
+            throw new FormatException($"The argument `{nameof(data)}` should contain {Size} bytes.");
 
-        Span<ulong> tmp = stackalloc ulong[LSIZE];
+        Span<ulong> tmp = stackalloc ulong[SizeL];
         BinaryPrimitives.TryReadUInt64BigEndian(data[0..8], out tmp[5]);
         BinaryPrimitives.TryReadUInt64BigEndian(data[8..16], out tmp[4]);
         BinaryPrimitives.TryReadUInt64BigEndian(data[16..24], out tmp[3]);
@@ -68,7 +67,7 @@ public readonly struct Fp : IEquatable<Fp>, INumber<Fp>
 
     public static Fp Random(RandomNumberGenerator rng)
     {
-        Span<byte> buffer = stackalloc byte[SIZE * 2];
+        Span<byte> buffer = stackalloc byte[Size * 2];
         rng.GetBytes(buffer);
         Span<Fp> d = MemoryMarshal.Cast<byte, Fp>(buffer);
         return d[0] * R2 + d[1] * R3;
@@ -277,12 +276,12 @@ public readonly struct Fp : IEquatable<Fp>, INumber<Fp>
             var (t0, t1, t2, t3, t4, t5, t6) = (u[0], u[1], u[2], u[3], u[4], u[5], 0ul);
             for (int i = 0; i < length; i++)
             {
-                (t0, carry) = Mac(t0, au[i * LSIZE + j], bu[i * LSIZE + 0], 0);
-                (t1, carry) = Mac(t1, au[i * LSIZE + j], bu[i * LSIZE + 1], carry);
-                (t2, carry) = Mac(t2, au[i * LSIZE + j], bu[i * LSIZE + 2], carry);
-                (t3, carry) = Mac(t3, au[i * LSIZE + j], bu[i * LSIZE + 3], carry);
-                (t4, carry) = Mac(t4, au[i * LSIZE + j], bu[i * LSIZE + 4], carry);
-                (t5, carry) = Mac(t5, au[i * LSIZE + j], bu[i * LSIZE + 5], carry);
+                (t0, carry) = Mac(t0, au[i * SizeL + j], bu[i * SizeL + 0], 0);
+                (t1, carry) = Mac(t1, au[i * SizeL + j], bu[i * SizeL + 1], carry);
+                (t2, carry) = Mac(t2, au[i * SizeL + j], bu[i * SizeL + 2], carry);
+                (t3, carry) = Mac(t3, au[i * SizeL + j], bu[i * SizeL + 3], carry);
+                (t4, carry) = Mac(t4, au[i * SizeL + j], bu[i * SizeL + 4], carry);
+                (t5, carry) = Mac(t5, au[i * SizeL + j], bu[i * SizeL + 5], carry);
                 (t6, _) = Adc(t6, 0, carry);
             }
 
@@ -364,7 +363,7 @@ public readonly struct Fp : IEquatable<Fp>, INumber<Fp>
     public static Fp operator *(in Fp a, in Fp b)
     {
         ReadOnlySpan<ulong> s = a.GetSpanU64(), r = b.GetSpanU64();
-        Span<ulong> t = stackalloc ulong[LSIZE * 2];
+        Span<ulong> t = stackalloc ulong[SizeL * 2];
         ulong carry;
 
         (t[0], carry) = Mac(0, s[0], r[0], 0);

--- a/src/Neo.Cryptography.BLS12_381/Fp12.cs
+++ b/src/Neo.Cryptography.BLS12_381/Fp12.cs
@@ -4,19 +4,20 @@ using System.Security.Cryptography;
 
 namespace Neo.Cryptography.BLS12_381;
 
-[StructLayout(LayoutKind.Explicit, Size = Size)]
+[StructLayout(LayoutKind.Explicit, Size = SIZE)]
 public readonly struct Fp12 : IEquatable<Fp12>, INumber<Fp12>
 {
     [FieldOffset(0)]
     public readonly Fp6 C0;
-    [FieldOffset(Fp6.Size)]
+    [FieldOffset(Fp6.SIZE)]
     public readonly Fp6 C1;
 
-    public const int Size = Fp6.Size * 2;
+    public const int SIZE = Fp6.SIZE * 2;
 
     private static readonly Fp12 _zero = new();
     private static readonly Fp12 _one = new(in Fp6.One);
 
+    public int Size => SIZE;
     public static ref readonly Fp12 Zero => ref _zero;
     public static ref readonly Fp12 One => ref _one;
 
@@ -45,10 +46,10 @@ public readonly struct Fp12 : IEquatable<Fp12>, INumber<Fp12>
 
     public static Fp12 FromBytes(ReadOnlySpan<byte> data)
     {
-        if (data.Length != Size)
-            throw new FormatException($"The argument `{nameof(data)}` should contain {Size} bytes.");
-        Fp6 c0 = Fp6.FromBytes(data[Fp6.Size..]);
-        Fp6 c1 = Fp6.FromBytes(data[..Fp6.Size]);
+        if (data.Length != SIZE)
+            throw new FormatException($"The argument `{nameof(data)}` should contain {SIZE} bytes.");
+        Fp6 c0 = Fp6.FromBytes(data[Fp6.SIZE..]);
+        Fp6 c1 = Fp6.FromBytes(data[..Fp6.SIZE]);
         return new(in c0, in c1);
     }
 
@@ -88,8 +89,8 @@ public readonly struct Fp12 : IEquatable<Fp12>, INumber<Fp12>
     public bool TryWrite(Span<byte> buffer)
     {
         if (buffer.Length < Size) return false;
-        C0.TryWrite(buffer[Fp6.Size..Size]);
-        C1.TryWrite(buffer[0..Fp6.Size]);
+        C0.TryWrite(buffer[Fp6.SIZE..Size]);
+        C1.TryWrite(buffer[0..Fp6.SIZE]);
         return true;
     }
 

--- a/src/Neo.Cryptography.BLS12_381/Fp12.cs
+++ b/src/Neo.Cryptography.BLS12_381/Fp12.cs
@@ -4,20 +4,20 @@ using System.Security.Cryptography;
 
 namespace Neo.Cryptography.BLS12_381;
 
-[StructLayout(LayoutKind.Explicit, Size = Size)]
+[StructLayout(LayoutKind.Explicit, Size = SIZE)]
 public readonly struct Fp12 : IEquatable<Fp12>, INumber<Fp12>
 {
     [FieldOffset(0)]
     public readonly Fp6 C0;
-    [FieldOffset(Fp6.Size)]
+    [FieldOffset(Fp6.SIZE)]
     public readonly Fp6 C1;
 
-    public const int Size = Fp6.Size * 2;
+    public const int SIZE = Fp6.SIZE * 2;
 
     private static readonly Fp12 _zero = new();
     private static readonly Fp12 _one = new(in Fp6.One);
 
-    static int INumber<Fp12>.Size => Size;
+    public int Size => SIZE;
     public static ref readonly Fp12 Zero => ref _zero;
     public static ref readonly Fp12 One => ref _one;
 
@@ -46,10 +46,10 @@ public readonly struct Fp12 : IEquatable<Fp12>, INumber<Fp12>
 
     public static Fp12 FromBytes(ReadOnlySpan<byte> data)
     {
-        if (data.Length != Size)
-            throw new FormatException($"The argument `{nameof(data)}` should contain {Size} bytes.");
-        Fp6 c0 = Fp6.FromBytes(data[Fp6.Size..]);
-        Fp6 c1 = Fp6.FromBytes(data[..Fp6.Size]);
+        if (data.Length != SIZE)
+            throw new FormatException($"The argument `{nameof(data)}` should contain {SIZE} bytes.");
+        Fp6 c0 = Fp6.FromBytes(data[Fp6.SIZE..]);
+        Fp6 c1 = Fp6.FromBytes(data[..Fp6.SIZE]);
         return new(in c0, in c1);
     }
 
@@ -89,8 +89,8 @@ public readonly struct Fp12 : IEquatable<Fp12>, INumber<Fp12>
     public bool TryWrite(Span<byte> buffer)
     {
         if (buffer.Length < Size) return false;
-        C0.TryWrite(buffer[Fp6.Size..Size]);
-        C1.TryWrite(buffer[0..Fp6.Size]);
+        C0.TryWrite(buffer[Fp6.SIZE..Size]);
+        C1.TryWrite(buffer[0..Fp6.SIZE]);
         return true;
     }
 

--- a/src/Neo.Cryptography.BLS12_381/Fp12.cs
+++ b/src/Neo.Cryptography.BLS12_381/Fp12.cs
@@ -4,20 +4,19 @@ using System.Security.Cryptography;
 
 namespace Neo.Cryptography.BLS12_381;
 
-[StructLayout(LayoutKind.Explicit, Size = SIZE)]
+[StructLayout(LayoutKind.Explicit, Size = Size)]
 public readonly struct Fp12 : IEquatable<Fp12>, INumber<Fp12>
 {
     [FieldOffset(0)]
     public readonly Fp6 C0;
-    [FieldOffset(Fp6.SIZE)]
+    [FieldOffset(Fp6.Size)]
     public readonly Fp6 C1;
 
-    public const int SIZE = Fp6.SIZE * 2;
+    public const int Size = Fp6.Size * 2;
 
     private static readonly Fp12 _zero = new();
     private static readonly Fp12 _one = new(in Fp6.One);
 
-    public int Size => SIZE;
     public static ref readonly Fp12 Zero => ref _zero;
     public static ref readonly Fp12 One => ref _one;
 
@@ -46,10 +45,10 @@ public readonly struct Fp12 : IEquatable<Fp12>, INumber<Fp12>
 
     public static Fp12 FromBytes(ReadOnlySpan<byte> data)
     {
-        if (data.Length != SIZE)
-            throw new FormatException($"The argument `{nameof(data)}` should contain {SIZE} bytes.");
-        Fp6 c0 = Fp6.FromBytes(data[Fp6.SIZE..]);
-        Fp6 c1 = Fp6.FromBytes(data[..Fp6.SIZE]);
+        if (data.Length != Size)
+            throw new FormatException($"The argument `{nameof(data)}` should contain {Size} bytes.");
+        Fp6 c0 = Fp6.FromBytes(data[Fp6.Size..]);
+        Fp6 c1 = Fp6.FromBytes(data[..Fp6.Size]);
         return new(in c0, in c1);
     }
 
@@ -89,8 +88,8 @@ public readonly struct Fp12 : IEquatable<Fp12>, INumber<Fp12>
     public bool TryWrite(Span<byte> buffer)
     {
         if (buffer.Length < Size) return false;
-        C0.TryWrite(buffer[Fp6.SIZE..Size]);
-        C1.TryWrite(buffer[0..Fp6.SIZE]);
+        C0.TryWrite(buffer[Fp6.Size..Size]);
+        C1.TryWrite(buffer[0..Fp6.Size]);
         return true;
     }
 

--- a/src/Neo.Cryptography.BLS12_381/Fp2.cs
+++ b/src/Neo.Cryptography.BLS12_381/Fp2.cs
@@ -5,20 +5,19 @@ using static Neo.Cryptography.BLS12_381.ConstantTimeUtility;
 
 namespace Neo.Cryptography.BLS12_381;
 
-[StructLayout(LayoutKind.Explicit, Size = SIZE)]
+[StructLayout(LayoutKind.Explicit, Size = Size)]
 public readonly struct Fp2 : IEquatable<Fp2>, INumber<Fp2>
 {
     [FieldOffset(0)]
     public readonly Fp C0;
-    [FieldOffset(Fp.SIZE)]
+    [FieldOffset(Fp.Size)]
     public readonly Fp C1;
 
-    public const int SIZE = Fp.SIZE * 2;
+    public const int Size = Fp.Size * 2;
 
     private static readonly Fp2 _zero = new();
     private static readonly Fp2 _one = new(in Fp.One);
 
-    public int Size => SIZE;
     public static ref readonly Fp2 Zero => ref _zero;
     public static ref readonly Fp2 One => ref _one;
 
@@ -37,10 +36,10 @@ public readonly struct Fp2 : IEquatable<Fp2>, INumber<Fp2>
 
     public static Fp2 FromBytes(ReadOnlySpan<byte> data)
     {
-        if (data.Length != SIZE)
-            throw new FormatException($"The argument `{nameof(data)}` should contain {SIZE} bytes.");
-        Fp c0 = Fp.FromBytes(data[Fp.SIZE..]);
-        Fp c1 = Fp.FromBytes(data[..Fp.SIZE]);
+        if (data.Length != Size)
+            throw new FormatException($"The argument `{nameof(data)}` should contain {Size} bytes.");
+        Fp c0 = Fp.FromBytes(data[Fp.Size..]);
+        Fp c1 = Fp.FromBytes(data[..Fp.Size]);
         return new(in c0, in c1);
     }
 
@@ -85,8 +84,8 @@ public readonly struct Fp2 : IEquatable<Fp2>, INumber<Fp2>
     public bool TryWrite(Span<byte> buffer)
     {
         if (buffer.Length < Size) return false;
-        C0.TryWrite(buffer[Fp.SIZE..Size]);
-        C1.TryWrite(buffer[0..Fp.SIZE]);
+        C0.TryWrite(buffer[Fp.Size..Size]);
+        C1.TryWrite(buffer[0..Fp.Size]);
         return true;
     }
 

--- a/src/Neo.Cryptography.BLS12_381/Fp2.cs
+++ b/src/Neo.Cryptography.BLS12_381/Fp2.cs
@@ -5,20 +5,20 @@ using static Neo.Cryptography.BLS12_381.ConstantTimeUtility;
 
 namespace Neo.Cryptography.BLS12_381;
 
-[StructLayout(LayoutKind.Explicit, Size = Size)]
+[StructLayout(LayoutKind.Explicit, Size = SIZE)]
 public readonly struct Fp2 : IEquatable<Fp2>, INumber<Fp2>
 {
     [FieldOffset(0)]
     public readonly Fp C0;
-    [FieldOffset(Fp.Size)]
+    [FieldOffset(Fp.SIZE)]
     public readonly Fp C1;
 
-    public const int Size = Fp.Size * 2;
+    public const int SIZE = Fp.SIZE * 2;
 
     private static readonly Fp2 _zero = new();
     private static readonly Fp2 _one = new(in Fp.One);
 
-    static int INumber<Fp2>.Size => Size;
+    public int Size => SIZE;
     public static ref readonly Fp2 Zero => ref _zero;
     public static ref readonly Fp2 One => ref _one;
 
@@ -37,10 +37,10 @@ public readonly struct Fp2 : IEquatable<Fp2>, INumber<Fp2>
 
     public static Fp2 FromBytes(ReadOnlySpan<byte> data)
     {
-        if (data.Length != Size)
-            throw new FormatException($"The argument `{nameof(data)}` should contain {Size} bytes.");
-        Fp c0 = Fp.FromBytes(data[Fp.Size..]);
-        Fp c1 = Fp.FromBytes(data[..Fp.Size]);
+        if (data.Length != SIZE)
+            throw new FormatException($"The argument `{nameof(data)}` should contain {SIZE} bytes.");
+        Fp c0 = Fp.FromBytes(data[Fp.SIZE..]);
+        Fp c1 = Fp.FromBytes(data[..Fp.SIZE]);
         return new(in c0, in c1);
     }
 
@@ -85,8 +85,8 @@ public readonly struct Fp2 : IEquatable<Fp2>, INumber<Fp2>
     public bool TryWrite(Span<byte> buffer)
     {
         if (buffer.Length < Size) return false;
-        C0.TryWrite(buffer[Fp.Size..Size]);
-        C1.TryWrite(buffer[0..Fp.Size]);
+        C0.TryWrite(buffer[Fp.SIZE..Size]);
+        C1.TryWrite(buffer[0..Fp.SIZE]);
         return true;
     }
 

--- a/src/Neo.Cryptography.BLS12_381/Fp2.cs
+++ b/src/Neo.Cryptography.BLS12_381/Fp2.cs
@@ -5,19 +5,20 @@ using static Neo.Cryptography.BLS12_381.ConstantTimeUtility;
 
 namespace Neo.Cryptography.BLS12_381;
 
-[StructLayout(LayoutKind.Explicit, Size = Size)]
+[StructLayout(LayoutKind.Explicit, Size = SIZE)]
 public readonly struct Fp2 : IEquatable<Fp2>, INumber<Fp2>
 {
     [FieldOffset(0)]
     public readonly Fp C0;
-    [FieldOffset(Fp.Size)]
+    [FieldOffset(Fp.SIZE)]
     public readonly Fp C1;
 
-    public const int Size = Fp.Size * 2;
+    public const int SIZE = Fp.SIZE * 2;
 
     private static readonly Fp2 _zero = new();
     private static readonly Fp2 _one = new(in Fp.One);
 
+    public int Size => SIZE;
     public static ref readonly Fp2 Zero => ref _zero;
     public static ref readonly Fp2 One => ref _one;
 
@@ -36,10 +37,10 @@ public readonly struct Fp2 : IEquatable<Fp2>, INumber<Fp2>
 
     public static Fp2 FromBytes(ReadOnlySpan<byte> data)
     {
-        if (data.Length != Size)
-            throw new FormatException($"The argument `{nameof(data)}` should contain {Size} bytes.");
-        Fp c0 = Fp.FromBytes(data[Fp.Size..]);
-        Fp c1 = Fp.FromBytes(data[..Fp.Size]);
+        if (data.Length != SIZE)
+            throw new FormatException($"The argument `{nameof(data)}` should contain {SIZE} bytes.");
+        Fp c0 = Fp.FromBytes(data[Fp.SIZE..]);
+        Fp c1 = Fp.FromBytes(data[..Fp.SIZE]);
         return new(in c0, in c1);
     }
 
@@ -84,8 +85,8 @@ public readonly struct Fp2 : IEquatable<Fp2>, INumber<Fp2>
     public bool TryWrite(Span<byte> buffer)
     {
         if (buffer.Length < Size) return false;
-        C0.TryWrite(buffer[Fp.Size..Size]);
-        C1.TryWrite(buffer[0..Fp.Size]);
+        C0.TryWrite(buffer[Fp.SIZE..Size]);
+        C1.TryWrite(buffer[0..Fp.SIZE]);
         return true;
     }
 

--- a/src/Neo.Cryptography.BLS12_381/Fp6.cs
+++ b/src/Neo.Cryptography.BLS12_381/Fp6.cs
@@ -4,22 +4,21 @@ using System.Security.Cryptography;
 
 namespace Neo.Cryptography.BLS12_381;
 
-[StructLayout(LayoutKind.Explicit, Size = SIZE)]
+[StructLayout(LayoutKind.Explicit, Size = Size)]
 public readonly struct Fp6 : IEquatable<Fp6>, INumber<Fp6>
 {
     [FieldOffset(0)]
     public readonly Fp2 C0;
-    [FieldOffset(Fp2.SIZE)]
+    [FieldOffset(Fp2.Size)]
     public readonly Fp2 C1;
-    [FieldOffset(Fp2.SIZE * 2)]
+    [FieldOffset(Fp2.Size * 2)]
     public readonly Fp2 C2;
 
-    public const int SIZE = Fp2.SIZE * 3;
+    public const int Size = Fp2.Size * 3;
 
     private static readonly Fp6 _zero = new();
     private static readonly Fp6 _one = new(in Fp2.One);
 
-    public int Size => SIZE;
     public static ref readonly Fp6 Zero => ref _zero;
     public static ref readonly Fp6 One => ref _one;
 
@@ -44,11 +43,11 @@ public readonly struct Fp6 : IEquatable<Fp6>, INumber<Fp6>
 
     public static Fp6 FromBytes(ReadOnlySpan<byte> data)
     {
-        if (data.Length != SIZE)
-            throw new FormatException($"The argument `{nameof(data)}` should contain {SIZE} bytes.");
-        Fp2 c0 = Fp2.FromBytes(data[(Fp2.SIZE * 2)..]);
-        Fp2 c1 = Fp2.FromBytes(data[Fp2.SIZE..(Fp2.SIZE * 2)]);
-        Fp2 c2 = Fp2.FromBytes(data[..Fp2.SIZE]);
+        if (data.Length != Size)
+            throw new FormatException($"The argument `{nameof(data)}` should contain {Size} bytes.");
+        Fp2 c0 = Fp2.FromBytes(data[(Fp2.Size * 2)..]);
+        Fp2 c1 = Fp2.FromBytes(data[Fp2.Size..(Fp2.Size * 2)]);
+        Fp2 c2 = Fp2.FromBytes(data[..Fp2.Size]);
         return new(in c0, in c1, in c2);
     }
 
@@ -88,9 +87,9 @@ public readonly struct Fp6 : IEquatable<Fp6>, INumber<Fp6>
     public bool TryWrite(Span<byte> buffer)
     {
         if (buffer.Length < Size) return false;
-        C0.TryWrite(buffer[(Fp2.SIZE * 2)..Size]);
-        C1.TryWrite(buffer[Fp2.SIZE..(Fp2.SIZE * 2)]);
-        C2.TryWrite(buffer[0..Fp2.SIZE]);
+        C0.TryWrite(buffer[(Fp2.Size * 2)..Size]);
+        C1.TryWrite(buffer[Fp2.Size..(Fp2.Size * 2)]);
+        C2.TryWrite(buffer[0..Fp2.Size]);
         return true;
     }
 

--- a/src/Neo.Cryptography.BLS12_381/Fp6.cs
+++ b/src/Neo.Cryptography.BLS12_381/Fp6.cs
@@ -4,21 +4,22 @@ using System.Security.Cryptography;
 
 namespace Neo.Cryptography.BLS12_381;
 
-[StructLayout(LayoutKind.Explicit, Size = Size)]
+[StructLayout(LayoutKind.Explicit, Size = SIZE)]
 public readonly struct Fp6 : IEquatable<Fp6>, INumber<Fp6>
 {
     [FieldOffset(0)]
     public readonly Fp2 C0;
-    [FieldOffset(Fp2.Size)]
+    [FieldOffset(Fp2.SIZE)]
     public readonly Fp2 C1;
-    [FieldOffset(Fp2.Size * 2)]
+    [FieldOffset(Fp2.SIZE * 2)]
     public readonly Fp2 C2;
 
-    public const int Size = Fp2.Size * 3;
+    public const int SIZE = Fp2.SIZE * 3;
 
     private static readonly Fp6 _zero = new();
     private static readonly Fp6 _one = new(in Fp2.One);
 
+    public int Size => SIZE;
     public static ref readonly Fp6 Zero => ref _zero;
     public static ref readonly Fp6 One => ref _one;
 
@@ -43,11 +44,11 @@ public readonly struct Fp6 : IEquatable<Fp6>, INumber<Fp6>
 
     public static Fp6 FromBytes(ReadOnlySpan<byte> data)
     {
-        if (data.Length != Size)
-            throw new FormatException($"The argument `{nameof(data)}` should contain {Size} bytes.");
-        Fp2 c0 = Fp2.FromBytes(data[(Fp2.Size * 2)..]);
-        Fp2 c1 = Fp2.FromBytes(data[Fp2.Size..(Fp2.Size * 2)]);
-        Fp2 c2 = Fp2.FromBytes(data[..Fp2.Size]);
+        if (data.Length != SIZE)
+            throw new FormatException($"The argument `{nameof(data)}` should contain {SIZE} bytes.");
+        Fp2 c0 = Fp2.FromBytes(data[(Fp2.SIZE * 2)..]);
+        Fp2 c1 = Fp2.FromBytes(data[Fp2.SIZE..(Fp2.SIZE * 2)]);
+        Fp2 c2 = Fp2.FromBytes(data[..Fp2.SIZE]);
         return new(in c0, in c1, in c2);
     }
 
@@ -87,9 +88,9 @@ public readonly struct Fp6 : IEquatable<Fp6>, INumber<Fp6>
     public bool TryWrite(Span<byte> buffer)
     {
         if (buffer.Length < Size) return false;
-        C0.TryWrite(buffer[(Fp2.Size * 2)..Size]);
-        C1.TryWrite(buffer[Fp2.Size..(Fp2.Size * 2)]);
-        C2.TryWrite(buffer[0..Fp2.Size]);
+        C0.TryWrite(buffer[(Fp2.SIZE * 2)..Size]);
+        C1.TryWrite(buffer[Fp2.SIZE..(Fp2.SIZE * 2)]);
+        C2.TryWrite(buffer[0..Fp2.SIZE]);
         return true;
     }
 

--- a/src/Neo.Cryptography.BLS12_381/Fp6.cs
+++ b/src/Neo.Cryptography.BLS12_381/Fp6.cs
@@ -4,22 +4,22 @@ using System.Security.Cryptography;
 
 namespace Neo.Cryptography.BLS12_381;
 
-[StructLayout(LayoutKind.Explicit, Size = Size)]
+[StructLayout(LayoutKind.Explicit, Size = SIZE)]
 public readonly struct Fp6 : IEquatable<Fp6>, INumber<Fp6>
 {
     [FieldOffset(0)]
     public readonly Fp2 C0;
-    [FieldOffset(Fp2.Size)]
+    [FieldOffset(Fp2.SIZE)]
     public readonly Fp2 C1;
-    [FieldOffset(Fp2.Size * 2)]
+    [FieldOffset(Fp2.SIZE * 2)]
     public readonly Fp2 C2;
 
-    public const int Size = Fp2.Size * 3;
+    public const int SIZE = Fp2.SIZE * 3;
 
     private static readonly Fp6 _zero = new();
     private static readonly Fp6 _one = new(in Fp2.One);
 
-    static int INumber<Fp6>.Size => Size;
+    public int Size => SIZE;
     public static ref readonly Fp6 Zero => ref _zero;
     public static ref readonly Fp6 One => ref _one;
 
@@ -44,11 +44,11 @@ public readonly struct Fp6 : IEquatable<Fp6>, INumber<Fp6>
 
     public static Fp6 FromBytes(ReadOnlySpan<byte> data)
     {
-        if (data.Length != Size)
-            throw new FormatException($"The argument `{nameof(data)}` should contain {Size} bytes.");
-        Fp2 c0 = Fp2.FromBytes(data[(Fp2.Size * 2)..]);
-        Fp2 c1 = Fp2.FromBytes(data[Fp2.Size..(Fp2.Size * 2)]);
-        Fp2 c2 = Fp2.FromBytes(data[..Fp2.Size]);
+        if (data.Length != SIZE)
+            throw new FormatException($"The argument `{nameof(data)}` should contain {SIZE} bytes.");
+        Fp2 c0 = Fp2.FromBytes(data[(Fp2.SIZE * 2)..]);
+        Fp2 c1 = Fp2.FromBytes(data[Fp2.SIZE..(Fp2.SIZE * 2)]);
+        Fp2 c2 = Fp2.FromBytes(data[..Fp2.SIZE]);
         return new(in c0, in c1, in c2);
     }
 
@@ -88,9 +88,9 @@ public readonly struct Fp6 : IEquatable<Fp6>, INumber<Fp6>
     public bool TryWrite(Span<byte> buffer)
     {
         if (buffer.Length < Size) return false;
-        C0.TryWrite(buffer[(Fp2.Size * 2)..Size]);
-        C1.TryWrite(buffer[Fp2.Size..(Fp2.Size * 2)]);
-        C2.TryWrite(buffer[0..Fp2.Size]);
+        C0.TryWrite(buffer[(Fp2.SIZE * 2)..Size]);
+        C1.TryWrite(buffer[Fp2.SIZE..(Fp2.SIZE * 2)]);
+        C2.TryWrite(buffer[0..Fp2.SIZE]);
         return true;
     }
 

--- a/src/Neo.Cryptography.BLS12_381/G1Projective.cs
+++ b/src/Neo.Cryptography.BLS12_381/G1Projective.cs
@@ -6,14 +6,14 @@ using static Neo.Cryptography.BLS12_381.G1Constants;
 
 namespace Neo.Cryptography.BLS12_381;
 
-[StructLayout(LayoutKind.Explicit, Size = Fp.Size * 3)]
+[StructLayout(LayoutKind.Explicit, Size = Fp.SIZE * 3)]
 public readonly struct G1Projective : IEquatable<G1Projective>
 {
     [FieldOffset(0)]
     public readonly Fp X;
-    [FieldOffset(Fp.Size)]
+    [FieldOffset(Fp.SIZE)]
     public readonly Fp Y;
-    [FieldOffset(Fp.Size * 2)]
+    [FieldOffset(Fp.SIZE * 2)]
     public readonly Fp Z;
 
     public static readonly G1Projective Identity = new(in Fp.Zero, in Fp.One, in Fp.Zero);

--- a/src/Neo.Cryptography.BLS12_381/G1Projective.cs
+++ b/src/Neo.Cryptography.BLS12_381/G1Projective.cs
@@ -6,14 +6,14 @@ using static Neo.Cryptography.BLS12_381.G1Constants;
 
 namespace Neo.Cryptography.BLS12_381;
 
-[StructLayout(LayoutKind.Explicit, Size = Fp.SIZE * 3)]
+[StructLayout(LayoutKind.Explicit, Size = Fp.Size * 3)]
 public readonly struct G1Projective : IEquatable<G1Projective>
 {
     [FieldOffset(0)]
     public readonly Fp X;
-    [FieldOffset(Fp.SIZE)]
+    [FieldOffset(Fp.Size)]
     public readonly Fp Y;
-    [FieldOffset(Fp.SIZE * 2)]
+    [FieldOffset(Fp.Size * 2)]
     public readonly Fp Z;
 
     public static readonly G1Projective Identity = new(in Fp.Zero, in Fp.One, in Fp.Zero);

--- a/src/Neo.Cryptography.BLS12_381/G2Projective.cs
+++ b/src/Neo.Cryptography.BLS12_381/G2Projective.cs
@@ -8,14 +8,14 @@ using static Neo.Cryptography.BLS12_381.G2Constants;
 
 namespace Neo.Cryptography.BLS12_381;
 
-[StructLayout(LayoutKind.Explicit, Size = Fp2.SIZE * 3)]
+[StructLayout(LayoutKind.Explicit, Size = Fp2.Size * 3)]
 public readonly struct G2Projective : IEquatable<G2Projective>
 {
     [FieldOffset(0)]
     public readonly Fp2 X;
-    [FieldOffset(Fp2.SIZE)]
+    [FieldOffset(Fp2.Size)]
     public readonly Fp2 Y;
-    [FieldOffset(Fp2.SIZE * 2)]
+    [FieldOffset(Fp2.Size * 2)]
     public readonly Fp2 Z;
 
     public static readonly G2Projective Identity = new(in Fp2.Zero, in Fp2.One, in Fp2.Zero);

--- a/src/Neo.Cryptography.BLS12_381/G2Projective.cs
+++ b/src/Neo.Cryptography.BLS12_381/G2Projective.cs
@@ -8,14 +8,14 @@ using static Neo.Cryptography.BLS12_381.G2Constants;
 
 namespace Neo.Cryptography.BLS12_381;
 
-[StructLayout(LayoutKind.Explicit, Size = Fp2.Size * 3)]
+[StructLayout(LayoutKind.Explicit, Size = Fp2.SIZE * 3)]
 public readonly struct G2Projective : IEquatable<G2Projective>
 {
     [FieldOffset(0)]
     public readonly Fp2 X;
-    [FieldOffset(Fp2.Size)]
+    [FieldOffset(Fp2.SIZE)]
     public readonly Fp2 Y;
-    [FieldOffset(Fp2.Size * 2)]
+    [FieldOffset(Fp2.SIZE * 2)]
     public readonly Fp2 Z;
 
     public static readonly G2Projective Identity = new(in Fp2.Zero, in Fp2.One, in Fp2.Zero);

--- a/src/Neo.Cryptography.BLS12_381/INumber.cs
+++ b/src/Neo.Cryptography.BLS12_381/INumber.cs
@@ -2,7 +2,7 @@ namespace Neo.Cryptography.BLS12_381;
 
 interface INumber<T> where T : unmanaged, INumber<T>
 {
-    static abstract int Size { get; }
+    abstract int Size { get; }
     static abstract ref readonly T Zero { get; }
     static abstract ref readonly T One { get; }
 

--- a/src/Neo.Cryptography.BLS12_381/INumber.cs
+++ b/src/Neo.Cryptography.BLS12_381/INumber.cs
@@ -2,6 +2,7 @@ namespace Neo.Cryptography.BLS12_381;
 
 interface INumber<T> where T : unmanaged, INumber<T>
 {
+    abstract int Size { get; }
     static abstract ref readonly T Zero { get; }
     static abstract ref readonly T One { get; }
 

--- a/src/Neo.Cryptography.BLS12_381/INumber.cs
+++ b/src/Neo.Cryptography.BLS12_381/INumber.cs
@@ -2,7 +2,6 @@ namespace Neo.Cryptography.BLS12_381;
 
 interface INumber<T> where T : unmanaged, INumber<T>
 {
-    abstract int Size { get; }
     static abstract ref readonly T Zero { get; }
     static abstract ref readonly T One { get; }
 

--- a/src/Neo.Cryptography.BLS12_381/MillerLoopResult.cs
+++ b/src/Neo.Cryptography.BLS12_381/MillerLoopResult.cs
@@ -3,7 +3,7 @@ using static Neo.Cryptography.BLS12_381.Constants;
 
 namespace Neo.Cryptography.BLS12_381;
 
-[StructLayout(LayoutKind.Explicit, Size = Fp12.Size)]
+[StructLayout(LayoutKind.Explicit, Size = Fp12.SIZE)]
 readonly struct MillerLoopResult
 {
     [FieldOffset(0)]

--- a/src/Neo.Cryptography.BLS12_381/MillerLoopResult.cs
+++ b/src/Neo.Cryptography.BLS12_381/MillerLoopResult.cs
@@ -3,7 +3,7 @@ using static Neo.Cryptography.BLS12_381.Constants;
 
 namespace Neo.Cryptography.BLS12_381;
 
-[StructLayout(LayoutKind.Explicit, Size = Fp12.SIZE)]
+[StructLayout(LayoutKind.Explicit, Size = Fp12.Size)]
 readonly struct MillerLoopResult
 {
     [FieldOffset(0)]

--- a/src/Neo.Cryptography.BLS12_381/Scalar.cs
+++ b/src/Neo.Cryptography.BLS12_381/Scalar.cs
@@ -9,13 +9,14 @@ using static Neo.Cryptography.BLS12_381.ScalarConstants;
 
 namespace Neo.Cryptography.BLS12_381;
 
-[StructLayout(LayoutKind.Explicit, Size = Size)]
+[StructLayout(LayoutKind.Explicit, Size = SIZE)]
 public readonly struct Scalar : IEquatable<Scalar>, INumber<Scalar>
 {
-    public const int Size = 32;
-    public const int SizeL = Size / sizeof(ulong);
+    public const int SIZE = 32;
+    public const int LSIZE = SIZE / sizeof(ulong);
     public static readonly Scalar Default = new();
 
+    public int Size => SIZE;
     public static ref readonly Scalar Zero => ref Default;
     public static ref readonly Scalar One => ref R;
 
@@ -31,7 +32,7 @@ public readonly struct Scalar : IEquatable<Scalar>, INumber<Scalar>
 
     public Scalar(ulong value)
     {
-        Span<ulong> data = stackalloc ulong[SizeL];
+        Span<ulong> data = stackalloc ulong[LSIZE];
         data[0] = value;
         this = FromRaw(data);
     }
@@ -45,8 +46,8 @@ public readonly struct Scalar : IEquatable<Scalar>, INumber<Scalar>
 
     public static Scalar FromBytes(ReadOnlySpan<byte> data)
     {
-        if (data.Length != Size)
-            throw new FormatException($"The argument `{nameof(data)}` should contain {Size} bytes.");
+        if (data.Length != SIZE)
+            throw new FormatException($"The argument `{nameof(data)}` should contain {SIZE} bytes.");
 
         ref readonly Scalar ref_ = ref MemoryMarshal.AsRef<Scalar>(data);
 
@@ -75,8 +76,8 @@ public readonly struct Scalar : IEquatable<Scalar>, INumber<Scalar>
 
     public static Scalar FromBytesWide(ReadOnlySpan<byte> data)
     {
-        if (data.Length != Size * 2)
-            throw new FormatException($"The argument `{nameof(data)}` should contain {Size * 2} bytes.");
+        if (data.Length != SIZE * 2)
+            throw new FormatException($"The argument `{nameof(data)}` should contain {SIZE * 2} bytes.");
 
         ReadOnlySpan<Scalar> d = MemoryMarshal.Cast<byte, Scalar>(data);
         return d[0] * R2 + d[1] * R3;
@@ -238,8 +239,8 @@ public readonly struct Scalar : IEquatable<Scalar>, INumber<Scalar>
 
     public Scalar Pow(ulong[] by)
     {
-        if (by.Length != SizeL)
-            throw new ArgumentException($"The length of the parameter `{nameof(by)}` must be {SizeL}.");
+        if (by.Length != LSIZE)
+            throw new ArgumentException($"The length of the parameter `{nameof(by)}` must be {LSIZE}.");
 
         var res = One;
         for (int j = by.Length - 1; j >= 0; j--)

--- a/src/Neo.Cryptography.BLS12_381/Scalar.cs
+++ b/src/Neo.Cryptography.BLS12_381/Scalar.cs
@@ -9,14 +9,13 @@ using static Neo.Cryptography.BLS12_381.ScalarConstants;
 
 namespace Neo.Cryptography.BLS12_381;
 
-[StructLayout(LayoutKind.Explicit, Size = SIZE)]
+[StructLayout(LayoutKind.Explicit, Size = Size)]
 public readonly struct Scalar : IEquatable<Scalar>, INumber<Scalar>
 {
-    public const int SIZE = 32;
-    public const int LSIZE = SIZE / sizeof(ulong);
+    public const int Size = 32;
+    public const int SizeL = Size / sizeof(ulong);
     public static readonly Scalar Default = new();
 
-    public int Size => SIZE;
     public static ref readonly Scalar Zero => ref Default;
     public static ref readonly Scalar One => ref R;
 
@@ -32,7 +31,7 @@ public readonly struct Scalar : IEquatable<Scalar>, INumber<Scalar>
 
     public Scalar(ulong value)
     {
-        Span<ulong> data = stackalloc ulong[LSIZE];
+        Span<ulong> data = stackalloc ulong[SizeL];
         data[0] = value;
         this = FromRaw(data);
     }
@@ -46,8 +45,8 @@ public readonly struct Scalar : IEquatable<Scalar>, INumber<Scalar>
 
     public static Scalar FromBytes(ReadOnlySpan<byte> data)
     {
-        if (data.Length != SIZE)
-            throw new FormatException($"The argument `{nameof(data)}` should contain {SIZE} bytes.");
+        if (data.Length != Size)
+            throw new FormatException($"The argument `{nameof(data)}` should contain {Size} bytes.");
 
         ref readonly Scalar ref_ = ref MemoryMarshal.AsRef<Scalar>(data);
 
@@ -76,8 +75,8 @@ public readonly struct Scalar : IEquatable<Scalar>, INumber<Scalar>
 
     public static Scalar FromBytesWide(ReadOnlySpan<byte> data)
     {
-        if (data.Length != SIZE * 2)
-            throw new FormatException($"The argument `{nameof(data)}` should contain {SIZE * 2} bytes.");
+        if (data.Length != Size * 2)
+            throw new FormatException($"The argument `{nameof(data)}` should contain {Size * 2} bytes.");
 
         ReadOnlySpan<Scalar> d = MemoryMarshal.Cast<byte, Scalar>(data);
         return d[0] * R2 + d[1] * R3;
@@ -239,8 +238,8 @@ public readonly struct Scalar : IEquatable<Scalar>, INumber<Scalar>
 
     public Scalar Pow(ulong[] by)
     {
-        if (by.Length != LSIZE)
-            throw new ArgumentException($"The length of the parameter `{nameof(by)}` must be {LSIZE}.");
+        if (by.Length != SizeL)
+            throw new ArgumentException($"The length of the parameter `{nameof(by)}` must be {SizeL}.");
 
         var res = One;
         for (int j = by.Length - 1; j >= 0; j--)

--- a/src/Neo.Cryptography.BLS12_381/Scalar.cs
+++ b/src/Neo.Cryptography.BLS12_381/Scalar.cs
@@ -9,14 +9,14 @@ using static Neo.Cryptography.BLS12_381.ScalarConstants;
 
 namespace Neo.Cryptography.BLS12_381;
 
-[StructLayout(LayoutKind.Explicit, Size = Size)]
+[StructLayout(LayoutKind.Explicit, Size = SIZE)]
 public readonly struct Scalar : IEquatable<Scalar>, INumber<Scalar>
 {
-    public const int Size = 32;
-    public const int SizeL = Size / sizeof(ulong);
+    public const int SIZE = 32;
+    public const int LSIZE = SIZE / sizeof(ulong);
     public static readonly Scalar Default = new();
 
-    static int INumber<Scalar>.Size => Size;
+    public int Size => SIZE;
     public static ref readonly Scalar Zero => ref Default;
     public static ref readonly Scalar One => ref R;
 
@@ -32,7 +32,7 @@ public readonly struct Scalar : IEquatable<Scalar>, INumber<Scalar>
 
     public Scalar(ulong value)
     {
-        Span<ulong> data = stackalloc ulong[SizeL];
+        Span<ulong> data = stackalloc ulong[LSIZE];
         data[0] = value;
         this = FromRaw(data);
     }
@@ -46,8 +46,8 @@ public readonly struct Scalar : IEquatable<Scalar>, INumber<Scalar>
 
     public static Scalar FromBytes(ReadOnlySpan<byte> data)
     {
-        if (data.Length != Size)
-            throw new FormatException($"The argument `{nameof(data)}` should contain {Size} bytes.");
+        if (data.Length != SIZE)
+            throw new FormatException($"The argument `{nameof(data)}` should contain {SIZE} bytes.");
 
         ref readonly Scalar ref_ = ref MemoryMarshal.AsRef<Scalar>(data);
 
@@ -76,8 +76,8 @@ public readonly struct Scalar : IEquatable<Scalar>, INumber<Scalar>
 
     public static Scalar FromBytesWide(ReadOnlySpan<byte> data)
     {
-        if (data.Length != Size * 2)
-            throw new FormatException($"The argument `{nameof(data)}` should contain {Size * 2} bytes.");
+        if (data.Length != SIZE * 2)
+            throw new FormatException($"The argument `{nameof(data)}` should contain {SIZE * 2} bytes.");
 
         ReadOnlySpan<Scalar> d = MemoryMarshal.Cast<byte, Scalar>(data);
         return d[0] * R2 + d[1] * R3;
@@ -239,8 +239,8 @@ public readonly struct Scalar : IEquatable<Scalar>, INumber<Scalar>
 
     public Scalar Pow(ulong[] by)
     {
-        if (by.Length != SizeL)
-            throw new ArgumentException($"The length of the parameter `{nameof(by)}` must be {SizeL}.");
+        if (by.Length != LSIZE)
+            throw new ArgumentException($"The length of the parameter `{nameof(by)}` must be {LSIZE}.");
 
         var res = One;
         for (int j = by.Length - 1; j >= 0; j--)

--- a/tests/Neo.Cryptography.BLS12_381.Tests/UT_Fp.cs
+++ b/tests/Neo.Cryptography.BLS12_381.Tests/UT_Fp.cs
@@ -10,7 +10,7 @@ public class UT_Fp
     [TestMethod]
     public void TestSize()
     {
-        Assert.AreEqual(Fp.SIZE, Marshal.SizeOf<Fp>());
+        Assert.AreEqual(Fp.Size, Marshal.SizeOf<Fp>());
     }
 
     [TestMethod]

--- a/tests/Neo.Cryptography.BLS12_381.Tests/UT_Fp.cs
+++ b/tests/Neo.Cryptography.BLS12_381.Tests/UT_Fp.cs
@@ -10,7 +10,7 @@ public class UT_Fp
     [TestMethod]
     public void TestSize()
     {
-        Assert.AreEqual(Fp.Size, Marshal.SizeOf<Fp>());
+        Assert.AreEqual(Fp.SIZE, Marshal.SizeOf<Fp>());
     }
 
     [TestMethod]


### PR DESCRIPTION
In order to improve the dotnet standard migration and reduce the risk changes, I want to remove the static methods one by one

In this PR:
- Remove `INumber.Size`