### PR TITLE
Remove static methods: One and Zero

### DIFF
--- a/src/Neo.Cryptography.BLS12_381/Bls12.Adder.cs
+++ b/src/Neo.Cryptography.BLS12_381/Bls12.Adder.cs
@@ -33,6 +33,6 @@ partial class Bls12
 
         static Fp12 IMillerLoopDriver<Fp12>.Conjugate(in Fp12 f) => f.Conjugate();
 
-        static Fp12 IMillerLoopDriver<Fp12>.One => Fp12.One;
+        static Fp12 IMillerLoopDriver<Fp12>.One => Fp12.ONE;
     }
 }

--- a/src/Neo.Cryptography.BLS12_381/Bls12.cs
+++ b/src/Neo.Cryptography.BLS12_381/Bls12.cs
@@ -14,7 +14,7 @@ public static partial class Bls12
         var adder = new Adder(p2, q2);
 
         var tmp = MillerLoop<Fp12, Adder>(adder);
-        var tmp2 = new MillerLoopResult(ConditionalSelect(in tmp, in Fp12.One, either_identity));
+        var tmp2 = new MillerLoopResult(ConditionalSelect(in tmp, in Fp12.ONE, either_identity));
         return tmp2.FinalExponentiation();
     }
 }

--- a/src/Neo.Cryptography.BLS12_381/Fp.cs
+++ b/src/Neo.Cryptography.BLS12_381/Fp.cs
@@ -15,11 +15,12 @@ public readonly struct Fp : IEquatable<Fp>, INumber<Fp>
     public const int Size = 48;
     public const int SizeL = Size / sizeof(ulong);
 
-    private static readonly Fp _zero = new();
+    public static readonly Fp ZERO = new();
+    public static readonly Fp ONE = R;
 
     static int INumber<Fp>.Size => Size;
-    public static ref readonly Fp Zero => ref _zero;
-    public static ref readonly Fp One => ref R;
+    public ref readonly Fp Zero => ref ZERO;
+    public ref readonly Fp One => ref ONE;
 
     public bool IsZero => this == Zero;
 

--- a/src/Neo.Cryptography.BLS12_381/Fp12.cs
+++ b/src/Neo.Cryptography.BLS12_381/Fp12.cs
@@ -14,27 +14,27 @@ public readonly struct Fp12 : IEquatable<Fp12>, INumber<Fp12>
 
     public const int Size = Fp6.Size * 2;
 
-    private static readonly Fp12 _zero = new();
-    private static readonly Fp12 _one = new(in Fp6.One);
+    public static readonly Fp12 ZERO = new();
+    public static readonly Fp12 ONE = new(in Fp6.ONE);
 
     static int INumber<Fp12>.Size => Size;
-    public static ref readonly Fp12 Zero => ref _zero;
-    public static ref readonly Fp12 One => ref _one;
+    public ref readonly Fp12 Zero => ref ZERO;
+    public ref readonly Fp12 One => ref ONE;
 
     public bool IsZero => C0.IsZero & C1.IsZero;
 
     public Fp12(in Fp f)
-        : this(new Fp6(in f), in Fp6.Zero)
+        : this(new Fp6(in f), in Fp6.ZERO)
     {
     }
 
     public Fp12(in Fp2 f)
-        : this(new Fp6(in f), in Fp6.Zero)
+        : this(new Fp6(in f), in Fp6.ZERO)
     {
     }
 
     public Fp12(in Fp6 f)
-        : this(in f, in Fp6.Zero)
+        : this(in f, in Fp6.ZERO)
     {
     }
 

--- a/src/Neo.Cryptography.BLS12_381/Fp2.cs
+++ b/src/Neo.Cryptography.BLS12_381/Fp2.cs
@@ -15,17 +15,17 @@ public readonly struct Fp2 : IEquatable<Fp2>, INumber<Fp2>
 
     public const int Size = Fp.Size * 2;
 
-    private static readonly Fp2 _zero = new();
-    private static readonly Fp2 _one = new(in Fp.One);
+    public static readonly Fp2 ZERO = new();
+    public static readonly Fp2 ONE = new(in Fp.ONE);
 
     static int INumber<Fp2>.Size => Size;
-    public static ref readonly Fp2 Zero => ref _zero;
-    public static ref readonly Fp2 One => ref _one;
+    public ref readonly Fp2 Zero => ref ZERO;
+    public ref readonly Fp2 One => ref ONE;
 
     public bool IsZero => C0.IsZero & C1.IsZero;
 
     public Fp2(in Fp f)
-        : this(in f, in Fp.Zero)
+        : this(in f, in Fp.ZERO)
     {
     }
 

--- a/src/Neo.Cryptography.BLS12_381/Fp6.cs
+++ b/src/Neo.Cryptography.BLS12_381/Fp6.cs
@@ -16,22 +16,22 @@ public readonly struct Fp6 : IEquatable<Fp6>, INumber<Fp6>
 
     public const int Size = Fp2.Size * 3;
 
-    private static readonly Fp6 _zero = new();
-    private static readonly Fp6 _one = new(in Fp2.One);
+    public static readonly Fp6 ZERO = new();
+    public static readonly Fp6 ONE = new(in Fp2.ONE);
 
     static int INumber<Fp6>.Size => Size;
-    public static ref readonly Fp6 Zero => ref _zero;
-    public static ref readonly Fp6 One => ref _one;
+    public ref readonly Fp6 Zero => ref ZERO;
+    public ref readonly Fp6 One => ref ONE;
 
     public bool IsZero => C0.IsZero & C1.IsZero & C2.IsZero;
 
     public Fp6(in Fp f)
-        : this(new Fp2(in f), in Fp2.Zero, in Fp2.Zero)
+        : this(new Fp2(in f), in Fp2.ZERO, in Fp2.ZERO)
     {
     }
 
     public Fp6(in Fp2 f)
-        : this(in f, in Fp2.Zero, in Fp2.Zero)
+        : this(in f, in Fp2.ZERO, in Fp2.ZERO)
     {
     }
 
@@ -143,7 +143,7 @@ public readonly struct Fp6 : IEquatable<Fp6>, INumber<Fp6>
         var c2 = C2.FrobeniusMap();
 
         // c1 = c1 * (u + 1)^((p - 1) / 3)
-        c1 *= new Fp2(in Fp.Zero, Fp.FromRawUnchecked(new ulong[]
+        c1 *= new Fp2(in Fp.ZERO, Fp.FromRawUnchecked(new ulong[]
         {
             0xcd03_c9e4_8671_f071,
             0x5dab_2246_1fcd_a5d2,
@@ -162,7 +162,7 @@ public readonly struct Fp6 : IEquatable<Fp6>, INumber<Fp6>
             0xa20d_1b8c_7e88_1024,
             0x14e4_f04f_e2db_9068,
             0x14e5_6d3f_1564_853a
-        }), in Fp.Zero);
+        }), in Fp.ZERO);
 
         return new Fp6(c0, c1, c2);
     }

--- a/src/Neo.Cryptography.BLS12_381/G1Affine.cs
+++ b/src/Neo.Cryptography.BLS12_381/G1Affine.cs
@@ -10,7 +10,7 @@ public readonly struct G1Affine : IEquatable<G1Affine>
     public readonly Fp Y;
     public readonly bool Infinity;
 
-    public static readonly G1Affine Identity = new(in Fp.Zero, in Fp.One, true);
+    public static readonly G1Affine Identity = new(in Fp.ZERO, in Fp.ONE, true);
     public static readonly G1Affine Generator = new(in GeneratorX, in GeneratorY, false);
 
     public bool IsIdentity => Infinity;
@@ -33,7 +33,7 @@ public readonly struct G1Affine : IEquatable<G1Affine>
     {
         bool s = p.Z.TryInvert(out Fp zinv);
 
-        zinv = ConditionalSelect(in Fp.Zero, in zinv, s);
+        zinv = ConditionalSelect(in Fp.ZERO, in zinv, s);
         Fp x = p.X * zinv;
         Fp y = p.Y * zinv;
 
@@ -119,12 +119,12 @@ public readonly struct G1Affine : IEquatable<G1Affine>
 
     public static G1Affine operator -(in G1Affine p)
     {
-        return new G1Affine(in p.X, ConditionalSelect(-p.Y, in Fp.One, p.Infinity), p.Infinity);
+        return new G1Affine(in p.X, ConditionalSelect(-p.Y, in Fp.ONE, p.Infinity), p.Infinity);
     }
 
     public byte[] ToCompressed()
     {
-        byte[] res = ConditionalSelect(in X, in Fp.Zero, Infinity).ToArray();
+        byte[] res = ConditionalSelect(in X, in Fp.ZERO, Infinity).ToArray();
 
         // This point is in compressed form, so we set the most significant bit.
         res[0] |= 0x80;
@@ -144,8 +144,8 @@ public readonly struct G1Affine : IEquatable<G1Affine>
     {
         byte[] res = GC.AllocateUninitializedArray<byte>(96);
 
-        ConditionalSelect(in X, in Fp.Zero, Infinity).TryWrite(res.AsSpan(0..48));
-        ConditionalSelect(in Y, in Fp.Zero, Infinity).TryWrite(res.AsSpan(48..96));
+        ConditionalSelect(in X, in Fp.ZERO, Infinity).TryWrite(res.AsSpan(0..48));
+        ConditionalSelect(in Y, in Fp.ZERO, Infinity).TryWrite(res.AsSpan(48..96));
 
         // Is this point at infinity? If so, set the second-most significant bit.
         res[0] |= ConditionalSelect((byte)0, (byte)0x40, Infinity);

--- a/src/Neo.Cryptography.BLS12_381/G1Projective.cs
+++ b/src/Neo.Cryptography.BLS12_381/G1Projective.cs
@@ -16,8 +16,8 @@ public readonly struct G1Projective : IEquatable<G1Projective>
     [FieldOffset(Fp.Size * 2)]
     public readonly Fp Z;
 
-    public static readonly G1Projective Identity = new(in Fp.Zero, in Fp.One, in Fp.Zero);
-    public static readonly G1Projective Generator = new(in GeneratorX, in GeneratorY, in Fp.One);
+    public static readonly G1Projective Identity = new(in Fp.ZERO, in Fp.ONE, in Fp.ZERO);
+    public static readonly G1Projective Generator = new(in GeneratorX, in GeneratorY, in Fp.ONE);
 
     public bool IsIdentity => Z.IsZero;
     public bool IsOnCurve => ((Y.Square() * Z) == (X.Square() * X + Z.Square() * Z * B)) | Z.IsZero;
@@ -30,7 +30,7 @@ public readonly struct G1Projective : IEquatable<G1Projective>
     }
 
     public G1Projective(in G1Affine p)
-        : this(in p.X, in p.Y, ConditionalSelect(in Fp.One, in Fp.Zero, p.Infinity))
+        : this(in p.X, in p.Y, ConditionalSelect(in Fp.ONE, in Fp.ZERO, p.Infinity))
     {
     }
 
@@ -262,7 +262,7 @@ public readonly struct G1Projective : IEquatable<G1Projective>
             throw new ArgumentException($"{nameof(p)} and {nameof(q)} must have the same length.");
 
         Span<Fp> x = stackalloc Fp[length];
-        Fp acc = Fp.One;
+        Fp acc = Fp.ONE;
         for (int i = 0; i < length; i++)
         {
             x[i] = acc;

--- a/src/Neo.Cryptography.BLS12_381/G2Affine.cs
+++ b/src/Neo.Cryptography.BLS12_381/G2Affine.cs
@@ -10,7 +10,7 @@ public readonly struct G2Affine : IEquatable<G2Affine>
     public readonly Fp2 Y;
     public readonly bool Infinity;
 
-    public static readonly G2Affine Identity = new(in Fp2.Zero, in Fp2.One, true);
+    public static readonly G2Affine Identity = new(in Fp2.ZERO, in Fp2.ONE, true);
     public static readonly G2Affine Generator = new(in GeneratorX, in GeneratorY, false);
 
     public bool IsIdentity => Infinity;
@@ -44,7 +44,7 @@ public readonly struct G2Affine : IEquatable<G2Affine>
     {
         bool s = p.Z.TryInvert(out Fp2 zinv);
 
-        zinv = ConditionalSelect(in Fp2.Zero, in zinv, s);
+        zinv = ConditionalSelect(in Fp2.ZERO, in zinv, s);
         Fp2 x = p.X * zinv;
         Fp2 y = p.Y * zinv;
 
@@ -87,7 +87,7 @@ public readonly struct G2Affine : IEquatable<G2Affine>
     {
         return new G2Affine(
             in a.X,
-            ConditionalSelect(-a.Y, in Fp2.One, a.Infinity),
+            ConditionalSelect(-a.Y, in Fp2.ONE, a.Infinity),
             a.Infinity
         );
     }
@@ -101,7 +101,7 @@ public readonly struct G2Affine : IEquatable<G2Affine>
     {
         // Strictly speaking, self.x is zero already when self.infinity is true, but
         // to guard against implementation mistakes we do not assume this.
-        var x = ConditionalSelect(in X, in Fp2.Zero, Infinity);
+        var x = ConditionalSelect(in X, in Fp2.ZERO, Infinity);
 
         var res = GC.AllocateUninitializedArray<byte>(96);
 
@@ -126,8 +126,8 @@ public readonly struct G2Affine : IEquatable<G2Affine>
     {
         var res = GC.AllocateUninitializedArray<byte>(192);
 
-        var x = ConditionalSelect(in X, in Fp2.Zero, Infinity);
-        var y = ConditionalSelect(in Y, in Fp2.Zero, Infinity);
+        var x = ConditionalSelect(in X, in Fp2.ZERO, Infinity);
+        var y = ConditionalSelect(in Y, in Fp2.ZERO, Infinity);
 
         x.C1.TryWrite(res.AsSpan(0..48));
         x.C0.TryWrite(res.AsSpan(48..96));

--- a/src/Neo.Cryptography.BLS12_381/G2Constants.cs
+++ b/src/Neo.Cryptography.BLS12_381/G2Constants.cs
@@ -59,7 +59,7 @@ static class G2Constants
     public static readonly Fp2 B3 = B + B + B;
 
     // 1 / ((u+1) ^ ((q-1)/3))
-    public static readonly Fp2 PsiCoeffX = new(in Fp.Zero, Fp.FromRawUnchecked(new ulong[]
+    public static readonly Fp2 PsiCoeffX = new(in Fp.ZERO, Fp.FromRawUnchecked(new ulong[]
     {
         0x890dc9e4867545c3,
         0x2af322533285a5d5,
@@ -97,5 +97,5 @@ static class G2Constants
         0x8eb60ebe01bacb9e,
         0x03f97d6e83d050d2,
         0x18f0206554638741
-    }), in Fp.Zero);
+    }), in Fp.ZERO);
 }

--- a/src/Neo.Cryptography.BLS12_381/G2Projective.cs
+++ b/src/Neo.Cryptography.BLS12_381/G2Projective.cs
@@ -18,8 +18,8 @@ public readonly struct G2Projective : IEquatable<G2Projective>
     [FieldOffset(Fp2.Size * 2)]
     public readonly Fp2 Z;
 
-    public static readonly G2Projective Identity = new(in Fp2.Zero, in Fp2.One, in Fp2.Zero);
-    public static readonly G2Projective Generator = new(in GeneratorX, in GeneratorY, in Fp2.One);
+    public static readonly G2Projective Identity = new(in Fp2.ZERO, in Fp2.ONE, in Fp2.ZERO);
+    public static readonly G2Projective Generator = new(in GeneratorX, in GeneratorY, in Fp2.ONE);
 
     public bool IsIdentity => Z.IsZero;
     public bool IsOnCurve => ((Y.Square() * Z) == (X.Square() * X + Z.Square() * Z * B)) | Z.IsZero; // Y^2 Z = X^3 + b Z^3
@@ -35,7 +35,7 @@ public readonly struct G2Projective : IEquatable<G2Projective>
     {
         X = p.X;
         Y = p.Y;
-        Z = ConditionalSelect(in Fp2.One, in Fp2.Zero, p.Infinity);
+        Z = ConditionalSelect(in Fp2.ONE, in Fp2.ZERO, p.Infinity);
     }
 
     public static bool operator ==(in G2Projective a, in G2Projective b)
@@ -305,7 +305,7 @@ public readonly struct G2Projective : IEquatable<G2Projective>
             throw new ArgumentException($"{nameof(p)} and {nameof(q)} must have the same length.");
 
         Span<Fp2> x = stackalloc Fp2[length];
-        Fp2 acc = Fp2.One;
+        Fp2 acc = Fp2.ONE;
         for (int i = 0; i < length; i++)
         {
             // We use the `x` field of `G2Affine` to store the product

--- a/src/Neo.Cryptography.BLS12_381/Gt.cs
+++ b/src/Neo.Cryptography.BLS12_381/Gt.cs
@@ -10,7 +10,7 @@ public readonly struct Gt : IEquatable<Gt>
 {
     public readonly Fp12 Value;
 
-    public static readonly Gt Identity = new(in Fp12.One);
+    public static readonly Gt Identity = new(in Fp12.ONE);
     public static readonly Gt Generator = new(in GeneratorValue);
 
     public bool IsIdentity => this == Identity;

--- a/src/Neo.Cryptography.BLS12_381/INumber.cs
+++ b/src/Neo.Cryptography.BLS12_381/INumber.cs
@@ -3,8 +3,8 @@ namespace Neo.Cryptography.BLS12_381;
 interface INumber<T> where T : unmanaged, INumber<T>
 {
     static abstract int Size { get; }
-    static abstract ref readonly T Zero { get; }
-    static abstract ref readonly T One { get; }
+    abstract ref readonly T Zero { get; }
+    abstract ref readonly T One { get; }
 
     static abstract T operator -(in T x);
     static abstract T operator +(in T x, in T y);
@@ -16,11 +16,11 @@ interface INumber<T> where T : unmanaged, INumber<T>
 
 static class NumberExtensions
 {
-    public static T PowVartime<T>(this T self, ulong[] by) where T : unmanaged, INumber<T>
+    private static T PowVartime<T>(T one, T self, ulong[] by) where T : unmanaged, INumber<T>
     {
         // Although this is labeled "vartime", it is only
         // variable time with respect to the exponent.
-        var res = T.One;
+        var res = one;
         for (int j = by.Length - 1; j >= 0; j--)
         {
             for (int i = 63; i >= 0; i--)
@@ -33,5 +33,20 @@ static class NumberExtensions
             }
         }
         return res;
+    }
+
+    public static Fp PowVartime(this Fp self, ulong[] by)
+    {
+        return PowVartime(Fp.ONE, self, by);
+    }
+
+    public static Fp2 PowVartime(this Fp2 self, ulong[] by)
+    {
+        return PowVartime(Fp2.ONE, self, by);
+    }
+
+    public static Scalar PowVartime(this Scalar self, ulong[] by)
+    {
+        return PowVartime(Scalar.ONE, self, by);
     }
 }

--- a/src/Neo.Cryptography.BLS12_381/MillerLoopResult.cs
+++ b/src/Neo.Cryptography.BLS12_381/MillerLoopResult.cs
@@ -72,7 +72,7 @@ readonly struct MillerLoopResult
         static Fp12 CycolotomicExp(in Fp12 f)
         {
             var x = BLS_X;
-            var tmp = Fp12.One;
+            var tmp = Fp12.ONE;
             var found_one = false;
             foreach (bool i in Enumerable.Range(0, 64).Select(b => ((x >> b) & 1) == 1).Reverse())
             {

--- a/src/Neo.Cryptography.BLS12_381/Scalar.cs
+++ b/src/Neo.Cryptography.BLS12_381/Scalar.cs
@@ -14,11 +14,12 @@ public readonly struct Scalar : IEquatable<Scalar>, INumber<Scalar>
 {
     public const int Size = 32;
     public const int SizeL = Size / sizeof(ulong);
-    public static readonly Scalar Default = new();
+    public static readonly Scalar ZERO = new();
+    public static readonly Scalar ONE = R;
 
     static int INumber<Scalar>.Size => Size;
-    public static ref readonly Scalar Zero => ref Default;
-    public static ref readonly Scalar One => ref R;
+    public ref readonly Scalar Zero => ref ZERO;
+    public ref readonly Scalar One => ref ONE;
 
     public bool IsZero => this == Zero;
 

--- a/tests/Neo.Cryptography.BLS12_381.Tests/UT_Fp.cs
+++ b/tests/Neo.Cryptography.BLS12_381.Tests/UT_Fp.cs
@@ -234,7 +234,7 @@ public class UT_Fp
             Assert.AreEqual(b, a);
         }
 
-        Assert.AreEqual(-Fp.One, Fp.FromBytes(new byte[]
+        Assert.AreEqual(-Fp.ONE, Fp.FromBytes(new byte[]
         {
             26, 1, 17, 234, 57, 127, 230, 154, 75, 27, 167, 182, 67, 75, 172, 215, 100, 119, 75,
             132, 243, 133, 18, 191, 103, 48, 210, 160, 246, 176, 246, 36, 30, 171, 255, 254, 177,
@@ -303,14 +303,14 @@ public class UT_Fp
         });
 
         Assert.AreEqual(b, a.Invert());
-        Assert.ThrowsException<DivideByZeroException>(() => Fp.Zero.Invert());
+        Assert.ThrowsException<DivideByZeroException>(() => Fp.ZERO.Invert());
     }
 
     [TestMethod]
     public void TestLexicographicLargest()
     {
-        Assert.IsFalse(Fp.Zero.LexicographicallyLargest());
-        Assert.IsFalse(Fp.One.LexicographicallyLargest());
+        Assert.IsFalse(Fp.ZERO.LexicographicallyLargest());
+        Assert.IsFalse(Fp.ONE.LexicographicallyLargest());
         Assert.IsFalse(Fp.FromRawUnchecked(new ulong[]
         {
             0xa1fa_ffff_fffe_5557,

--- a/tests/Neo.Cryptography.BLS12_381.Tests/UT_Fp12.cs
+++ b/tests/Neo.Cryptography.BLS12_381.Tests/UT_Fp12.cs
@@ -314,7 +314,7 @@ public class UT_Fp12
         Assert.AreEqual((a + b) * c.Square(), (c * c * a) + (c * c * b));
 
         Assert.AreEqual(a.Invert() * b.Invert(), (a * b).Invert());
-        Assert.AreEqual(Fp12.One, a.Invert() * a);
+        Assert.AreEqual(Fp12.ONE, a.Invert() * a);
 
         Assert.AreNotEqual(a, a.FrobeniusMap());
         Assert.AreEqual(

--- a/tests/Neo.Cryptography.BLS12_381.Tests/UT_Fp2.cs
+++ b/tests/Neo.Cryptography.BLS12_381.Tests/UT_Fp2.cs
@@ -339,7 +339,7 @@ public class UT_Fp2
             0xc52a_8b8d_6387_695d,
             0x9fb4_e61d_1e83_eac5,
             0x005c_b922_afe8_4dc7,
-        }), Fp.Zero);
+        }), Fp.ZERO);
 
         Assert.AreEqual(b, b.Sqrt().Square());
 
@@ -353,7 +353,7 @@ public class UT_Fp2
             0x755d_6e3d_fe1f_fc12,
             0xd36c_d6db_5547_e905,
             0x02f8_c8ec_bf18_67bb,
-        }), Fp.Zero);
+        }), Fp.ZERO);
 
         Assert.AreEqual(c, c.Sqrt().Square());
 
@@ -418,14 +418,14 @@ public class UT_Fp2
         }));
         Assert.AreEqual(b, a.Invert());
 
-        Assert.ThrowsException<DivideByZeroException>(() => Fp2.Zero.Invert());
+        Assert.ThrowsException<DivideByZeroException>(() => Fp2.ZERO.Invert());
     }
 
     [TestMethod]
     public void TestLexicographicLargest()
     {
-        Assert.IsFalse(Fp2.Zero.LexicographicallyLargest());
-        Assert.IsFalse(Fp2.One.LexicographicallyLargest());
+        Assert.IsFalse(Fp2.ZERO.LexicographicallyLargest());
+        Assert.IsFalse(Fp2.ONE.LexicographicallyLargest());
         Assert.IsTrue(new Fp2(Fp.FromRawUnchecked(new ulong[]
         {
             0x1128_ecad_6754_9455,
@@ -468,7 +468,7 @@ public class UT_Fp2
             0xe98a_d408_11f5_fc2b,
             0x736c_3a59_232d_511d,
             0x10ac_d42d_29cf_cbb6,
-        }), Fp.Zero).LexicographicallyLargest());
+        }), Fp.ZERO).LexicographicallyLargest());
         Assert.IsTrue(new Fp2(-Fp.FromRawUnchecked(new ulong[]
         {
             0x1128_ecad_6754_9455,
@@ -477,6 +477,6 @@ public class UT_Fp2
             0xe98a_d408_11f5_fc2b,
             0x736c_3a59_232d_511d,
             0x10ac_d42d_29cf_cbb6,
-        }), Fp.Zero).LexicographicallyLargest());
+        }), Fp.ZERO).LexicographicallyLargest());
     }
 }

--- a/tests/Neo.Cryptography.BLS12_381.Tests/UT_Fp6.cs
+++ b/tests/Neo.Cryptography.BLS12_381.Tests/UT_Fp6.cs
@@ -163,6 +163,6 @@ public class UT_Fp6
         Assert.AreEqual((a + b) * c.Square(), (c * c * a) + (c * c * b));
 
         Assert.AreEqual(a.Invert() * b.Invert(), (a * b).Invert());
-        Assert.AreEqual(Fp6.One, a.Invert() * a);
+        Assert.AreEqual(Fp6.ONE, a.Invert() * a);
     }
 }

--- a/tests/Neo.Cryptography.BLS12_381.Tests/UT_G1.cs
+++ b/tests/Neo.Cryptography.BLS12_381.Tests/UT_G1.cs
@@ -17,9 +17,9 @@ public class UT_G1
             0xe6, 0xf8, 0x96, 0x88, 0xde, 0x17, 0xd8, 0x13, 0x62, 0x0a, 0x00, 0x02, 0x2e, 0x01,
             0xff, 0xff, 0xff, 0xfe, 0xff, 0xfe
         }), BETA);
-        Assert.AreNotEqual(Fp.One, BETA);
-        Assert.AreNotEqual(Fp.One, BETA * BETA);
-        Assert.AreEqual(Fp.One, BETA * BETA * BETA);
+        Assert.AreNotEqual(Fp.ONE, BETA);
+        Assert.AreNotEqual(Fp.ONE, BETA * BETA);
+        Assert.AreEqual(Fp.ONE, BETA * BETA * BETA);
     }
 
     [TestMethod]
@@ -289,7 +289,7 @@ public class UT_G1
                 0x8c6d_883d_2516_c9a2,
                 0x0bc3_b8d5_fb04_47f7,
                 0x07bf_a4c7_210f_4f44,
-            }), in Fp.One)), new G1Affine(c));
+            }), in Fp.ONE)), new G1Affine(c));
             Assert.IsFalse(c.IsIdentity);
             Assert.IsTrue(c.IsOnCurve);
         }
@@ -395,7 +395,7 @@ public class UT_G1
                 0x8c6d_883d_2516_c9a2,
                 0x0bc3_b8d5_fb04_47f7,
                 0x07bf_a4c7_210f_4f44
-            }), Fp.One)), new G1Affine(c));
+            }), Fp.ONE)), new G1Affine(c));
             Assert.IsFalse(c.IsIdentity);
             Assert.IsTrue(c.IsOnCurve);
         }

--- a/tests/Neo.Cryptography.BLS12_381.Tests/UT_G2.cs
+++ b/tests/Neo.Cryptography.BLS12_381.Tests/UT_G2.cs
@@ -309,7 +309,7 @@ public class UT_G2
                 0x8eb6_0ebe_01ba_cb9e,
                 0x03f9_7d6e_83d0_50d2,
                 0x18f0_2065_5463_8741
-            }), Fp.Zero);
+            }), Fp.ZERO);
             beta = beta.Square();
             var a = G2Projective.Generator.Double().Double();
             var b = new G2Projective(a.X * beta, -a.Y, in a.Z);
@@ -351,7 +351,7 @@ public class UT_G2
                 0x4cb8_932d_d31d_af28,
                 0x62bb_fac6_db05_2a54,
                 0x11f9_5c16_d14c_3bbe
-            })), Fp2.One)));
+            })), Fp2.ONE)));
             Assert.IsFalse(c.IsIdentity);
             Assert.IsTrue(c.IsOnCurve);
         }
@@ -452,7 +452,7 @@ public class UT_G2
                 0x8eb6_0ebe_01ba_cb9e,
                 0x03f9_7d6e_83d0_50d2,
                 0x18f0_2065_5463_8741
-            }), Fp.Zero);
+            }), Fp.ZERO);
             beta = beta.Square();
             var _a = G2Projective.Generator.Double().Double();
             var b = new G2Projective(_a.X * beta, -_a.Y, in _a.Z);
@@ -493,7 +493,7 @@ public class UT_G2
                 0x4cb8_932d_d31d_af28,
                 0x62bb_fac6_db05_2a54,
                 0x11f9_5c16_d14c_3bbe
-            })), Fp2.One)), new G2Affine(c));
+            })), Fp2.ONE)), new G2Affine(c));
             Assert.IsFalse(c.IsIdentity);
             Assert.IsTrue(c.IsOnCurve);
         }

--- a/tests/Neo.Cryptography.BLS12_381.Tests/UT_Pairings.cs
+++ b/tests/Neo.Cryptography.BLS12_381.Tests/UT_Pairings.cs
@@ -52,7 +52,7 @@ public class UT_Pairings
     {
         Assert.AreEqual(
             Gt.Identity,
-            new MillerLoopResult(Fp12.One).FinalExponentiation()
+            new MillerLoopResult(Fp12.ONE).FinalExponentiation()
         );
     }
 }

--- a/tests/Neo.Cryptography.BLS12_381.Tests/UT_Scalar.cs
+++ b/tests/Neo.Cryptography.BLS12_381.Tests/UT_Scalar.cs
@@ -33,20 +33,20 @@ public class UT_Scalar
     [TestMethod]
     public void TestToString()
     {
-        Assert.AreEqual("0x0000000000000000000000000000000000000000000000000000000000000000", Scalar.Zero.ToString());
-        Assert.AreEqual("0x0000000000000000000000000000000000000000000000000000000000000001", Scalar.One.ToString());
+        Assert.AreEqual("0x0000000000000000000000000000000000000000000000000000000000000000", Scalar.ZERO.ToString());
+        Assert.AreEqual("0x0000000000000000000000000000000000000000000000000000000000000001", Scalar.ONE.ToString());
         Assert.AreEqual("0x1824b159acc5056f998c4fefecbc4ff55884b7fa0003480200000001fffffffe", R2.ToString());
     }
 
     [TestMethod]
     public void TestEquality()
     {
-        Assert.AreEqual(Scalar.Zero, Scalar.Zero);
-        Assert.AreEqual(Scalar.One, Scalar.One);
+        Assert.AreEqual(Scalar.ZERO, Scalar.ZERO);
+        Assert.AreEqual(Scalar.ONE, Scalar.ONE);
         Assert.AreEqual(R2, R2);
 
-        Assert.AreNotEqual(Scalar.Zero, Scalar.One);
-        Assert.AreNotEqual(Scalar.One, R2);
+        Assert.AreNotEqual(Scalar.ZERO, Scalar.ONE);
+        Assert.AreNotEqual(Scalar.ONE, R2);
     }
 
     [TestMethod]
@@ -56,13 +56,13 @@ public class UT_Scalar
         {
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0
-        }, Scalar.Zero.ToArray());
+        }, Scalar.ZERO.ToArray());
 
         CollectionAssert.AreEqual(new byte[]
         {
             1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0
-        }, Scalar.One.ToArray());
+        }, Scalar.ONE.ToArray());
 
         CollectionAssert.AreEqual(new byte[]
         {
@@ -74,19 +74,19 @@ public class UT_Scalar
         {
             0, 0, 0, 0, 255, 255, 255, 255, 254, 91, 254, 255, 2, 164, 189, 83, 5, 216, 161, 9, 8,
             216, 57, 51, 72, 125, 157, 41, 83, 167, 237, 115
-        }, (-Scalar.One).ToArray());
+        }, (-Scalar.ONE).ToArray());
     }
 
     [TestMethod]
     public void TestFromBytes()
     {
-        Assert.AreEqual(Scalar.Zero, Scalar.FromBytes(new byte[]
+        Assert.AreEqual(Scalar.ZERO, Scalar.FromBytes(new byte[]
         {
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0
         }));
 
-        Assert.AreEqual(Scalar.One, Scalar.FromBytes(new byte[]
+        Assert.AreEqual(Scalar.ONE, Scalar.FromBytes(new byte[]
         {
             1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0
@@ -144,7 +144,7 @@ public class UT_Scalar
     [TestMethod]
     public void TestFromBytesWideNegativeOne()
     {
-        Assert.AreEqual(-Scalar.One, Scalar.FromBytesWide(new byte[]
+        Assert.AreEqual(-Scalar.ONE, Scalar.FromBytesWide(new byte[]
         {
             0, 0, 0, 0, 255, 255, 255, 255, 254, 91, 254, 255, 2, 164, 189, 83, 5, 216, 161, 9, 8,
             216, 57, 51, 72, 125, 157, 41, 83, 167, 237, 115, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -167,10 +167,10 @@ public class UT_Scalar
     [TestMethod]
     public void TestZero()
     {
-        Assert.AreEqual(Scalar.Zero, -Scalar.Zero);
-        Assert.AreEqual(Scalar.Zero, Scalar.Zero + Scalar.Zero);
-        Assert.AreEqual(Scalar.Zero, Scalar.Zero - Scalar.Zero);
-        Assert.AreEqual(Scalar.Zero, Scalar.Zero * Scalar.Zero);
+        Assert.AreEqual(Scalar.ZERO, -Scalar.ZERO);
+        Assert.AreEqual(Scalar.ZERO, Scalar.ZERO + Scalar.ZERO);
+        Assert.AreEqual(Scalar.ZERO, Scalar.ZERO - Scalar.ZERO);
+        Assert.AreEqual(Scalar.ZERO, Scalar.ZERO * Scalar.ZERO);
     }
 
     [TestMethod]
@@ -190,7 +190,7 @@ public class UT_Scalar
         tmp = LARGEST;
         tmp += new Scalar(new ulong[] { 1, 0, 0, 0 });
 
-        Assert.AreEqual(Scalar.Zero, tmp);
+        Assert.AreEqual(Scalar.ZERO, tmp);
     }
 
     [TestMethod]
@@ -200,8 +200,8 @@ public class UT_Scalar
 
         Assert.AreEqual(new Scalar(new ulong[] { 1, 0, 0, 0 }), tmp);
 
-        tmp = -Scalar.Zero;
-        Assert.AreEqual(Scalar.Zero, tmp);
+        tmp = -Scalar.ZERO;
+        Assert.AreEqual(Scalar.ZERO, tmp);
         tmp = -new Scalar(new ulong[] { 1, 0, 0, 0 });
         Assert.AreEqual(LARGEST, tmp);
     }
@@ -212,9 +212,9 @@ public class UT_Scalar
         var tmp = LARGEST;
         tmp -= LARGEST;
 
-        Assert.AreEqual(Scalar.Zero, tmp);
+        Assert.AreEqual(Scalar.ZERO, tmp);
 
-        tmp = Scalar.Zero;
+        tmp = Scalar.ZERO;
         tmp -= LARGEST;
 
         var tmp2 = MODULUS;
@@ -233,7 +233,7 @@ public class UT_Scalar
             var tmp = cur;
             tmp *= cur;
 
-            var tmp2 = Scalar.Zero;
+            var tmp2 = Scalar.ZERO;
             foreach (bool b in cur
                 .ToArray()
                 .SelectMany(p => Enumerable.Range(0, 8).Select(q => ((p >> q) & 1) == 1))
@@ -264,7 +264,7 @@ public class UT_Scalar
             var tmp = cur;
             tmp = tmp.Square();
 
-            var tmp2 = Scalar.Zero;
+            var tmp2 = Scalar.ZERO;
             foreach (bool b in cur
                 .ToArray()
                 .SelectMany(p => Enumerable.Range(0, 8).Select(q => ((p >> q) & 1) == 1))
@@ -288,9 +288,9 @@ public class UT_Scalar
     [TestMethod]
     public void TestInversion()
     {
-        Assert.ThrowsException<DivideByZeroException>(() => Scalar.Zero.Invert());
-        Assert.AreEqual(Scalar.One, Scalar.One.Invert());
-        Assert.AreEqual(-Scalar.One, (-Scalar.One).Invert());
+        Assert.ThrowsException<DivideByZeroException>(() => Scalar.ZERO.Invert());
+        Assert.AreEqual(Scalar.ONE, Scalar.ONE.Invert());
+        Assert.AreEqual(-Scalar.ONE, (-Scalar.ONE).Invert());
 
         var tmp = R2;
 
@@ -299,7 +299,7 @@ public class UT_Scalar
             var tmp2 = tmp.Invert();
             tmp2 *= tmp;
 
-            Assert.AreEqual(Scalar.One, tmp2);
+            Assert.AreEqual(Scalar.ONE, tmp2);
 
             tmp += R2;
         }
@@ -338,7 +338,7 @@ public class UT_Scalar
     [TestMethod]
     public void TestSqrt()
     {
-        Assert.AreEqual(Scalar.Zero.Sqrt(), Scalar.Zero);
+        Assert.AreEqual(Scalar.ZERO.Sqrt(), Scalar.ZERO);
 
         var square = new Scalar(new ulong[]
         {
@@ -362,7 +362,7 @@ public class UT_Scalar
             {
                 none_count++;
             }
-            square -= Scalar.One;
+            square -= Scalar.ONE;
         }
 
         Assert.AreEqual(49, none_count);
@@ -379,7 +379,7 @@ public class UT_Scalar
             0x1824_b159_acc5_056f
         }), Scalar.FromRaw(Enumerable.Repeat(0xffff_ffff_ffff_ffff, 4).ToArray()));
 
-        Assert.AreEqual(Scalar.Zero, Scalar.FromRaw(MODULUS_LIMBS_64));
+        Assert.AreEqual(Scalar.ZERO, Scalar.FromRaw(MODULUS_LIMBS_64));
 
         Assert.AreEqual(R, Scalar.FromRaw(new ulong[] { 1, 0, 0, 0 }));
     }


### PR DESCRIPTION
In order to improve the dotnet standard migration and reduce the risk changes, I want to remove the static methods one by one

In this PR:

Remove `One and Zero`